### PR TITLE
[FIXED JENKINS-20522] Proper usage of TopLevelItemDescriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.jvnet.hudson.plugins</groupId>
-		<artifactId>plugin</artifactId>
-		<version>1.395</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plugin</artifactId>
+            <version>1.424</version>
 	</parent>
 
 	<artifactId>view-job-filters</artifactId>

--- a/src/main/java/hudson/views/JobTypeFilter.java
+++ b/src/main/java/hudson/views/JobTypeFilter.java
@@ -1,13 +1,13 @@
 package hudson.views;
 
-import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -29,20 +29,17 @@ public class JobTypeFilter extends AbstractIncludeExcludeJobFilter {
 
 	public TopLevelItemDescriptor getJobType() {
 		for (TopLevelItemDescriptor type: Items.all()) {
-			if (matches(type)) {
+			if (type.getId().equals(jobType)) {
 				return type;
 			}
 		}
 		return null;
 	}
 
-	private boolean matches(TopLevelItemDescriptor type) {
-        return type.clazz.getName().equals(jobType);
-    }
-
 	@Override
 	protected boolean matches(TopLevelItem item) {
-        return matches(item.getDescriptor());
+        TopLevelItemDescriptor d = getJobType();
+        return d != null && d.testInstance(item);
 	}
 
 	@Extension
@@ -51,13 +48,8 @@ public class JobTypeFilter extends AbstractIncludeExcludeJobFilter {
 		public String getDisplayName() {
 			return "Job Type Filter";
 		}
-		public List<TopLevelItemDescriptor> getJobTypes() {
-			List<TopLevelItemDescriptor> types = new ArrayList<TopLevelItemDescriptor>();
-			DescriptorExtensionList<TopLevelItem, TopLevelItemDescriptor> all = Items.all();
-			for (TopLevelItemDescriptor one: all) {
-				types.add(one);
-			}
-			return types;
+		public List<TopLevelItemDescriptor> getJobTypes(ItemGroup<?> context) {
+            return DescriptorVisibilityFilter.apply(context, Items.all());
 		}
 	}
 }

--- a/src/main/java/hudson/views/MavenExtraStepsValuesHelper.java
+++ b/src/main/java/hudson/views/MavenExtraStepsValuesHelper.java
@@ -21,8 +21,7 @@ public class MavenExtraStepsValuesHelper implements PluginHelperTestable {
 		if (item instanceof MavenModuleSet) {
 			MavenModuleSet set = (MavenModuleSet) item;
 
-			List<BuildWrapper> wrappers = set.getBuildWrappersList().toList();
-			for (BuildWrapper wrapper : wrappers) {
+			for (BuildWrapper wrapper : set.getBuildWrappers()) {
 				if (wrapper instanceof M2ExtraStepsWrapper) {
 					M2ExtraStepsWrapper mwrap = (M2ExtraStepsWrapper) wrapper;
 					MavenValuesHelper.addValues(values, mwrap

--- a/src/main/resources/hudson/views/JobTypeFilter/config.jelly
+++ b/src/main/resources/hudson/views/JobTypeFilter/config.jelly
@@ -3,8 +3,8 @@
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <f:entry title="${%Job Type}" field="jobType">
     <select name="jobType" class="setting-input">
-    	<j:forEach var="type" items="${descriptor.getJobTypes()}">
-	      <f:option value="${type.clazz.name}" selected="${instance.jobType == type}">${type.displayName}</f:option>
+    	<j:forEach var="type" items="${descriptor.getJobTypes(it.ownerItemGroup)}">
+	      <f:option value="${type.id}" selected="${instance.jobType == type}">${type.displayName}</f:option>
       	</j:forEach>
     </select>
   </f:entry>


### PR DESCRIPTION
Fixes [JENKINS-20522](https://issues.jenkins-ci.org/browse/JENKINS-20522) and related issues needed for use with the CloudBees Templates plugin and perhaps others. Most crucially, avoids using `Descriptor.clazz`, which does not work with dynamic descriptors.