### PR TITLE
added Job Color filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 work
+.idea
+*.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
 			<scope>compile</scope>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.0.31-beta</version>
+			<scope>test</scope>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/hudson/views/JobColorFilter.java
+++ b/src/main/java/hudson/views/JobColorFilter.java
@@ -1,0 +1,48 @@
+package hudson.views;
+
+
+import hudson.Extension;
+
+import hudson.model.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class JobColorFilter extends AbstractIncludeExcludeJobFilter {
+
+    private BallColor ballColor;
+
+    @DataBoundConstructor
+    public JobColorFilter(String ballColorTypeString,
+                          String includeExcludeTypeString) {
+        super(includeExcludeTypeString);
+        this.ballColor = BallColor.valueOf(ballColorTypeString.toUpperCase());
+    }
+
+    @SuppressWarnings("rawtypes")
+    protected boolean matches(TopLevelItem item) {
+
+        if (item instanceof Job) {
+            Job job = (Job) item;
+            Run last = job.getLastCompletedBuild();
+            if (last != null) {
+                BallColor jobBallColor = last.getIconColor();
+                if (ballColor == jobBallColor) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ViewJobFilter> {
+        @Override
+        public String getDisplayName() {
+            return "Job Color Filter";
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/view-color-filters/include-exclude-help.html";
+        }
+    }
+}

--- a/src/main/resources/hudson/views/JobColorFilter/config.jelly
+++ b/src/main/resources/hudson/views/JobColorFilter/config.jelly
@@ -1,0 +1,23 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <f:entry title="${%Job Colors}:">
+    <select name="ballColorTypeString" class="setting-input">
+        <f:option value="red" selected="${instance.red}">${%Red}</f:option>
+        <f:option value="yellow" selected="${instance.yellow}">${%Yellow}</f:option>
+        <f:option value="blue" selected="${instance.blue}">${%Blue}</f:option>
+        <f:option value="grey" selected="${instance.grey}">${%Grey}</f:option>
+        <f:option value="disabled" selected="${instance.disabled}">${%Disabled}</f:option>
+        <f:option value="aborted" selected="${instance.aborted}">${%Aborted}</f:option>
+        <f:option value="notbuilt" selected="${instance.notbuilt}">${%Not Built}</f:option>
+
+        <f:option value="yellow_anime" selected="${instance.yellow_anime}">${%Yellow In Progress}</f:option>
+        <f:option value="blue_anime" selected="${instance.blue_anime}">${%Blue In Progress}</f:option>
+        <f:option value="grey_anime" selected="${instance.grey_anime}">${%Grey In Progress}</f:option>
+        <f:option value="disabled_anime" selected="${instance.disabled_anime}">${%Disabled In Progress}</f:option>
+        <f:option value="aborted_anime" selected="${instance.aborted_anime}">${%Aborted In Progress}</f:option>
+        <f:option value="notbuilt_anime" selected="${instance.notbuilt_anime}">${%Not Built In Progress}</f:option>
+    </select>
+  </f:entry>
+  <st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>
+</j:jelly>

--- a/src/test/java/hudson/views/JobColorFilterTest.java
+++ b/src/test/java/hudson/views/JobColorFilterTest.java
@@ -1,0 +1,80 @@
+package hudson.views;
+
+import hudson.model.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JobColorFilterTest {
+    JobColorFilter filter;
+    String includeExcludeType = AbstractIncludeExcludeJobFilter.IncludeExcludeType.includeMatched.toString();
+    TopLevelJob job = mock(TopLevelJob.class);
+    Run run = mock(Run.class);
+    BallColor ballColor = BallColor.RED;
+
+    private abstract class TopLevelJob  extends Job implements TopLevelItem {
+        protected TopLevelJob(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+    }
+
+    @Before
+    public void setup(){
+        when(job.getLastCompletedBuild()).thenReturn(run);
+        filter = new JobColorFilter(BallColor.RED.toString(), includeExcludeType);
+    }
+
+    @Test
+    public void shouldNotMatchWhenTopLevelItemIsNotAJob(){
+
+        TopLevelItem item  = mock(TopLevelItem.class);
+
+        boolean isMatch = filter.matches(item);
+
+        assertFalse(isMatch);
+    }
+
+    @Test
+    public void shouldMatchColorWhenRequestedColorMatchesJobColor() {
+
+        when(run.getIconColor()).thenReturn(ballColor);
+
+        boolean isMatch = filter.matches(job);
+
+        assertTrue(isMatch);
+    }
+
+    @Test
+    public void shouldNotMatchColorWhenRequestedColorDoesNotMatchJobColor() {
+
+        when(run.getIconColor()).thenReturn(BallColor.ABORTED);
+
+        boolean isMatch = filter.matches(job);
+
+        assertFalse(isMatch);
+    }
+
+    @Test
+    public void shouldNotMatchWhenThereIsNotALastCompletedBuild(){
+
+        when(job.getLastCompletedBuild()).thenReturn(null);
+
+        boolean isMatch = filter.matches(job);
+
+        assertFalse(isMatch);
+    }
+
+    @Test
+    public void ballColorStringShouldBeCaseInsensitive(){
+        try {
+            filter = new JobColorFilter(BallColor.RED.toString().toLowerCase(), includeExcludeType);
+        } catch (IllegalArgumentException e) {
+            fail("Ball color string should be case insensitive");
+        }
+    }
+}


### PR DESCRIPTION
The Job Color filter allows jobs to be filtered based on Ball color. 

It is intended to be used in conjunction with the TextFinder plugin to allow views to be created based on specific text in the console output.

More information is on [Stack Overflow](http://stackoverflow.com/questions/8148122/how-to-mark-a-build-unstable-in-jenkins-when-running-shell-scripts).
