### PR TITLE
FIX JENKINS 31710

### DIFF
--- a/src/main/java/hudson/views/ScmTypeFilter.java
+++ b/src/main/java/hudson/views/ScmTypeFilter.java
@@ -7,11 +7,15 @@ import hudson.model.SCMedItem;
 import hudson.model.TopLevelItem;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
+import hudson.util.ReflectionUtils;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.util.ClassUtils;
 
 public class ScmTypeFilter extends AbstractIncludeExcludeJobFilter {
 
@@ -57,6 +61,56 @@ public class ScmTypeFilter extends AbstractIncludeExcludeJobFilter {
 			if (matches(descriptor)) {
 				return true;
 			}
+		} else {
+	    	/*
+    		 * FIX JENKINS-31710
+    		 * To keep backward compatibility with the required core '1.509.3' 
+    		 * (which doesn't contains the interface jenkins.triggers.SCMTriggerItem),
+    		 * we use reflection to get the appropriate method and data.
+    		 * This approach is effective but ugly, the best option is to require an newer version of Jenkins core (> 1.568).
+    		 * TODO: Update the required core version and simple replace this code with:
+    		 * 
+    		 * if (item instanceof jenkins.triggers.SCMTriggerItem) {
+    		 *    for (SCM scm : ((SCMTriggerItem) item).getSCMs()) {
+    		 *        SCMDescriptor descriptor = scm.getDescriptor();
+    		 *        // if one of then matches, then include the item
+    		 *        if (matches(descriptor)) {
+    		 *        		return true;
+    		 *        }
+    		 *    }
+    		 * }
+    		 */
+    		Class[] interfaces = ClassUtils.getAllInterfaces(item);
+
+    		// check if there are any interfaces
+    		if (interfaces != null && interfaces.length > 0) {
+	    		for (Class iface : interfaces) {
+
+	    			// check if the item implements the right interface
+	    			if (iface.getCanonicalName().equals("jenkins.triggers.SCMTriggerItem")) {
+
+	    				// get the method which returns the list of SCM items
+	    				Method getSCMs = ReflectionUtils.findMethod(item.getClass(), "getSCMs");
+
+	    				// get the return and convert it
+	    				@SuppressWarnings("unchecked")
+						Collection<? extends SCM> scms = (Collection<? extends SCM>)ReflectionUtils.invokeMethod(getSCMs, item);
+
+	    				// normal approach over all items
+	    				if (scms != null && !scms.isEmpty()) {
+	    		    		for (SCM scm : scms) {
+	    		    			SCMDescriptor descriptor = scm.getDescriptor();
+	    		    			// if one of then matches, then include the item
+	    		    			if (matches(descriptor)) {
+	    		    				return true;
+	    		    			}
+	    		    		}
+	    	    		}
+
+	    				break;
+	    			}
+	    		}
+	    	}
 		}
 		return false;
 	}


### PR DESCRIPTION
Fix JENKINS-31710 and also fixes JENKINS-29991, the fix was done by making the ScmTypeFilter and the RegExJobFilter compatible with the SCMTriggerItem interface.
The fix is compatible with the required core 1.581 (through reflections).
