### PR TITLE
Try using ACI agents for Linux builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useAci: true)


### PR DESCRIPTION
Since as seen in https://github.com/jenkinsci/view-job-filters-plugin/pull/15#issuecomment-606724482, the EC2 agents do not work.