### PR TITLE
Added a filter by build name.

### DIFF
--- a/src/main/java/hudson/views/RegExJobFilter.java
+++ b/src/main/java/hudson/views/RegExJobFilter.java
@@ -7,6 +7,7 @@ import hudson.scm.SCM;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -115,6 +116,25 @@ public class RegExJobFilter extends AbstractIncludeExcludeJobFilter {
 					}
 					if (options.matchFullDisplayName) {
 						values.add(item.getParent().getFullDisplayName());
+					}
+				}
+			}
+		},
+		BUILD_NAME {
+			@Override
+			void doGetMatchValues(TopLevelItem item, Options options, List<String> values) {
+				if (item.getAllJobs() != null) {
+					ArrayList<Job> jobs = new ArrayList<>(item.getAllJobs());
+					for (Job job : jobs) {
+						for (Iterator iterator = job.getBuilds().listIterator(); iterator.hasNext(); ) {
+							Run run = (Run) iterator.next();
+							if (options.matchName || options.matchDisplayName) {
+								values.add(run.getDisplayName());
+							}
+							if (options.matchFullName || options.matchFullDisplayName) {
+								values.add(run.getFullDisplayName());
+							}
+						}
 					}
 				}
 			}

--- a/src/main/resources/hudson/views/RegExJobFilter/config.jelly
+++ b/src/main/resources/hudson/views/RegExJobFilter/config.jelly
@@ -16,6 +16,7 @@
         <f:option value="MAVEN" selected="${instance.valueTypeString == 'MAVEN'}">${%Maven configuration}</f:option>
         <f:option value="SCHEDULE" selected="${instance.valueTypeString == 'SCHEDULE'}">${%Job schedule}</f:option>
         <f:option value="NODE" selected="${instance.valueTypeString == 'NODE'}">${%Node label expression}</f:option>
+        <f:option value="BUILD_NAME" selected="${instance.valueTypeString == 'BUILD_NAME'}">${%Build name}</f:option>
       </select>
       <div class="nameOptions" style="display: ${(empty instance.valueTypeString || instance.valueTypeString.contains('NAME')) ? 'block' : 'none'}">
         <f:checkbox name="matchName" field="matchName" default="true" /> ${%Name}

--- a/src/main/resources/hudson/views/RegExJobFilter/config_de.properties
+++ b/src/main/resources/hudson/views/RegExJobFilter/config_de.properties
@@ -9,6 +9,7 @@ Email\ recipients=Email-Empf\u00E4nger
 Maven\ configuration=Maven-Konfiguration
 Job\ schedule=Build-Zeitplan
 Node\ label\ expression=Node Label Ausdruck
+Build\ name=Build-Name
 
 Name=Name
 Full\ name=Vollst\u00E4ndiger Name

--- a/src/main/webapp/regex-help.html
+++ b/src/main/webapp/regex-help.html
@@ -43,6 +43,7 @@
             <li><i>Node label expression</i>: matches against the Label Expression under the "Restrict where this
                 project can be run" option.
             </li>
+            <li><i>Build name</i>: matches by display name of build</li>
         </ul>
     </dd>
     <dt>Match type:</dt>

--- a/src/main/webapp/regex-help_de.html
+++ b/src/main/webapp/regex-help_de.html
@@ -53,6 +53,7 @@
             <li><i>Node Label Ausdruck</i>: Vergleich mit dem Label-Ausdruck der Option "Beschränke, wo dieses Projekt
                 ausgeführt werden darf".
             </li>
+            <li><i>Build name</i>: Auswahl nach display-namen des builds</li>
         </ul>
     </dd>
     <dt>Filter-Typ:</dt>


### PR DESCRIPTION
Maybe it will be useful. For example, in our company and some people on the Internet, you really need to filter issues by the build name.

For example, the build name is set to the version that is being built and it happens that the job is the same but it collects different versions and you can use this filter to find out if the task needs a version.