### PR TITLE
Feature/jenkins-64480

### DIFF
--- a/src/main/java/hudson/views/BuildStatusFilter.java
+++ b/src/main/java/hudson/views/BuildStatusFilter.java
@@ -13,15 +13,18 @@ public class BuildStatusFilter extends AbstractIncludeExcludeJobFilter {
 	private boolean neverBuilt;
 	private boolean building;
 	private boolean inBuildQueue;
+	private boolean buildable;
 	
 	@DataBoundConstructor
 	public BuildStatusFilter(boolean neverBuilt,
 			boolean building, boolean inBuildQueue,
+			boolean buildable,
 			String includeExcludeTypeString) {
 		super(includeExcludeTypeString);
 		this.neverBuilt = neverBuilt;
 		this.building = building;
 		this.inBuildQueue = inBuildQueue;
+		this.buildable = buildable;
 	}
 	@SuppressWarnings("rawtypes")
 	protected boolean matches(TopLevelItem item) {
@@ -33,6 +36,9 @@ public class BuildStatusFilter extends AbstractIncludeExcludeJobFilter {
 			if (inBuildQueue && job.isInQueue()) {
 				return true;
 			}
+			if (buildable && job.isBuildable()){
+			    return true;
+            }
 			Run last = job.getLastBuild();
 			if (last == null && neverBuilt) {
 				return true;
@@ -62,4 +68,7 @@ public class BuildStatusFilter extends AbstractIncludeExcludeJobFilter {
 	public boolean isInBuildQueue() {
 		return inBuildQueue;
 	}
+	public boolean isBuildable() {
+	    return buildable;
+    }
 }

--- a/src/main/resources/hudson/views/BuildStatusFilter/config.jelly
+++ b/src/main/resources/hudson/views/BuildStatusFilter/config.jelly
@@ -6,6 +6,7 @@
     <f:checkbox name="building" field="building"/> ${%Currently Building}
     <f:checkbox name="neverBuilt" field="neverBuilt"/> ${%Never Built}
     <f:checkbox name="inBuildQueue" field="inBuildQueue"/> ${%In Build Queue}
+    <f:checkbox name="buildable" field="buildable"/> ${%Is Buildable}
   </f:entry>
   <st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>
 </j:jelly>

--- a/src/test/java/hudson/views/BuildStatusFilterTest.java
+++ b/src/test/java/hudson/views/BuildStatusFilterTest.java
@@ -25,24 +25,27 @@ public class BuildStatusFilterTest extends AbstractJenkinsTest {
 	public void testMatch() {
 		Build build = mock(Build.class);
 
-		assertFalse(buildStatus(true, true, true).matches(mock(TopLevelItem.class)));
+		assertFalse(buildStatus(true, true, true, true).matches(mock(TopLevelItem.class)));
 
 		for (JobType<? extends Job> type: availableJobTypes(FREE_STYLE_PROJECT, MATRIX_PROJECT, MAVEN_MODULE_SET)) {
-			assertTrue(buildStatus(true, false, false).matches(jobOfType(type).lastBuild(null).asItem()));
-			assertTrue(buildStatus(true, true, false).matches(jobOfType(type).lastBuild(null).asItem()));
-			assertTrue(buildStatus(true, false, true).matches(jobOfType(type).lastBuild(null).asItem()));
-			assertFalse(buildStatus(true, false, false).matches(jobOfType(type).lastBuild(build).asItem()));
-			assertFalse(buildStatus(false, false, false).matches(jobOfType(type).lastBuild(null).asItem()));
+			assertTrue(buildStatus(true, false, false, true).matches(jobOfType(type).lastBuild(null).asItem()));
+			assertTrue(buildStatus(true, true, false, true).matches(jobOfType(type).lastBuild(null).asItem()));
+			assertTrue(buildStatus(true, false, true, true).matches(jobOfType(type).lastBuild(null).asItem()));
+			assertFalse(buildStatus(true, false, false, true).matches(jobOfType(type).lastBuild(build).asItem()));
+			assertFalse(buildStatus(false, false, false, true).matches(jobOfType(type).lastBuild(null).asItem()));
 
-			assertTrue(buildStatus(false, true, false).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
-			assertTrue(buildStatus(true, true, false).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
-			assertTrue(buildStatus(false, true, true).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
-			assertFalse(buildStatus(false, true, false).matches(jobOfType(type).building(false).lastBuild(build).asItem()));
+			assertTrue(buildStatus(false, true, false, true).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
+			assertTrue(buildStatus(true, true, false, true).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
+			assertTrue(buildStatus(false, true, true, true).matches(jobOfType(type).building(true).lastBuild(build).asItem()));
+			assertFalse(buildStatus(false, true, false, true).matches(jobOfType(type).building(false).lastBuild(build).asItem()));
 
-			assertTrue(buildStatus(false, false, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
-			assertTrue(buildStatus(true, false, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
-			assertTrue(buildStatus(false, true, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
-			assertFalse(buildStatus(false, false, true).matches(jobOfType(type).inQueue(false).lastBuild(build).asItem()));
+			assertTrue(buildStatus(false, false, true, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
+			assertTrue(buildStatus(true, false, true, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
+			assertTrue(buildStatus(false, true, true, true).matches(jobOfType(type).inQueue(true).lastBuild(build).asItem()));
+			assertFalse(buildStatus(false, false, true, true).matches(jobOfType(type).inQueue(false).lastBuild(build).asItem()));
+
+            assertTrue(buildStatus(false, false, false, true).matches(jobOfType(type).buildable(true).lastBuild(build).asItem()));
+            assertFalse(buildStatus(false, false, false, false).matches(jobOfType(type).buildable(true).lastBuild(null).asItem()));
 		}
 	}
 
@@ -50,13 +53,14 @@ public class BuildStatusFilterTest extends AbstractJenkinsTest {
 	public void testConfigRoundtrip() throws Exception {
 		testConfigRoundtrip(
 			"view-1",
-			new BuildStatusFilter(false, true, false, excludeMatched.name())
+			new BuildStatusFilter(false, true, false, true, excludeMatched.name())
 		);
 
 		testConfigRoundtrip(
 			"view-2",
-			new BuildStatusFilter(true, false, true, includeMatched.name()),
-			new BuildStatusFilter(true, true, false, excludeMatched.name())
+			new BuildStatusFilter(true, false, true, true, includeMatched.name()),
+			new BuildStatusFilter(true, true, false, true, excludeMatched.name()),
+            new BuildStatusFilter(true, true, false, false, excludeMatched.name())
 		);
 	}
 
@@ -67,6 +71,7 @@ public class BuildStatusFilterTest extends AbstractJenkinsTest {
 				filter.isNeverBuilt(),
 				filter.isBuilding(),
 				filter.isInBuildQueue(),
+				filter.isBuildable(),
 				filter.getIncludeExcludeTypeString()));
 		}
 
@@ -92,6 +97,7 @@ public class BuildStatusFilterTest extends AbstractJenkinsTest {
 			assertThat(((BuildStatusFilter)actualFilter).isNeverBuilt(), is(expectedFilter.isNeverBuilt()));
 			assertThat(((BuildStatusFilter)actualFilter).isBuilding(), is(expectedFilter.isBuilding()));
 			assertThat(((BuildStatusFilter)actualFilter).isInBuildQueue(), is(expectedFilter.isInBuildQueue()));
+			assertThat(((BuildStatusFilter)actualFilter).isBuildable(), is(expectedFilter.isBuildable()));
 			assertThat(((BuildStatusFilter)actualFilter).getIncludeExcludeTypeString(), is(expectedFilter.getIncludeExcludeTypeString()));
 		}
 	}

--- a/src/test/java/hudson/views/test/JobMocker.java
+++ b/src/test/java/hudson/views/test/JobMocker.java
@@ -115,6 +115,12 @@ public class JobMocker<T extends Job> {
         return this;
     }
 
+    public JobMocker<T> buildable(boolean buildable) {
+        when(job.isBuildable()).thenReturn(buildable);
+        return this;
+    }
+
+
     public JobMocker<T> building(boolean building) {
         when(job.isBuilding()).thenReturn(building);
         return this;

--- a/src/test/java/hudson/views/test/ViewJobFilters.java
+++ b/src/test/java/hudson/views/test/ViewJobFilters.java
@@ -87,11 +87,13 @@ public class ViewJobFilters {
     public static BuildStatusFilter buildStatus(
             boolean neverBuild,
             boolean building,
-            boolean inBuildQueue) {
+            boolean inBuildQueue,
+            boolean buildable) {
         return new BuildStatusFilter(
                 neverBuild,
                 building,
                 inBuildQueue,
+                buildable,
                 includeMatched.name());
     }
 


### PR DESCRIPTION
Extending Build Statuses Filter to include `buildable` boolean, so that you can set filter to exclude branches that were recently deleted but not pruned (i.e. not buildable)