### PR TITLE
Building on both jdk8 and jdk11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
         [ platform: "linux", jdk: "8" ],
         [ platform: "linux", jdk: "11" ],
         [ platform: "windows", jdk: "8" ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(useAci: true)
+buildPlugin(configurations: [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "11", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
-        [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "11", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
+        [ platform: "linux", jdk: "8" ],
+        [ platform: "linux", jdk: "11" ],
+        [ platform: "windows", jdk: "8" ],
 ])


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This enables dual build on jdk8/jdk11.
Remove deprecated `useAci` option.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
