### PR TITLE
Fix PCT on 2.387.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-        [ platform: "linux", jdk: "8" ],
         [ platform: "linux", jdk: "11" ],
-        [ platform: "windows", jdk: "8" ],
+        [ platform: "windows", jdk: "11" ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>email-ext</artifactId>
-            <version>2.69</version>
+            <version>2.94</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.55</version>
         <relativePath />
     </parent>
 
@@ -30,15 +30,15 @@
         </license>
     </licenses>
     <properties>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>9</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>1887.vda_d0ddb_c15c4</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/test/java/hudson/views/BuildFilterColumnTest.java
+++ b/src/test/java/hudson/views/BuildFilterColumnTest.java
@@ -1,5 +1,6 @@
 package hudson.views;
 
+import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.Functions;
@@ -7,6 +8,7 @@ import hudson.model.*;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -26,17 +28,17 @@ public class BuildFilterColumnTest extends AbstractJenkinsTest {
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("icon-blue"));
+        assertThat(getBuildFilterColumn(view).querySelector("svg").getAttributes().getNamedItem("title").getTextContent(), containsString("Success"));
 
         runWithParameter(project, Result.FAILURE, "BRANCH", "master");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("icon-red"));
+        assertThat(getBuildFilterColumn(view).querySelector("svg").getAttributes().getNamedItem("title").getTextContent(), containsString("Failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
         runWithParameter(project, Result.FAILURE, "BRANCH", "test");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("icon-blue"));
+        assertThat(getBuildFilterColumn(view).querySelector("svg").getAttributes().getNamedItem("title").getTextContent(), containsString("Success"));
     }
 
     @Test
@@ -48,32 +50,32 @@ public class BuildFilterColumnTest extends AbstractJenkinsTest {
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.FAILURE, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("00to19"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("All recent builds failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("40to59"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("1 out of the last 2 builds failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("60to79"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("1 out of the last 3 builds failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("60to79"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("1 out of the last 4 builds failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("60to79"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("1 out of the last 5 builds failed"));
 
         runWithParameter(project, Result.SUCCESS, "BRANCH", "test");
         runWithParameter(project, Result.SUCCESS, "BRANCH", "master");
 
-        assertThat(getBuildFilterColumn(view).querySelector("img").getAttributes().getNamedItem("class").getTextContent(), containsString("80plus"));
+        assertThat(getBuildFilterColumn(view).getAttributes().getNamedItem("data-html-tooltip").getTextContent(), containsString("No recent builds failed"));
     }
 
     private FreeStyleProject createProject() throws IOException {
@@ -101,6 +103,6 @@ public class BuildFilterColumnTest extends AbstractJenkinsTest {
 
     private DomNode getBuildFilterColumn(ListView view) throws IOException, SAXException {
         HtmlPage viewPage = j.createWebClient().getPage(view);
-        return viewPage.querySelectorAll(".bigtable > tbody > tr > td").get(0);
+        return viewPage.querySelectorAll(".jenkins-table > tbody > tr > td").get(0);
     }
 }

--- a/src/test/java/hudson/views/BuildFilterColumnTest.java
+++ b/src/test/java/hudson/views/BuildFilterColumnTest.java
@@ -1,6 +1,5 @@
 package hudson.views;
 
-import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.Functions;
@@ -8,7 +7,6 @@ import hudson.model.*;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Update parent, bom and Jenkins baseline. 
This is fixing a PCT error when running against 2.387.x:

```
Exception class=[net.sourceforge.htmlunit.corejs.javascript.EvaluatorException]
com.gargoylesoftware.htmlunit.ScriptException: SyntaxError: invalid object initializer (http://localhost:33445/jenkins/static/68f3fdd7/jsbundles/app.js#97)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine$HtmlUnitContextAction.run(JavaScriptEngine.java:883)
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:617)
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:534)
[...]
	at hudson.views.AddRemoveFallbackFilterTest.testConfigRoundtrip(AddRemoveFallbackFilterTest.java:112)
	at hudson.views.AddRemoveFallbackFilterTest.testConfigRoundtrip(AddRemoveFallbackFilterTest.java:88)
[...]
```

A total of 23 test failures are failing with the same stack trace.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
