### PR TITLE
Reduce usage of Mockito

### DIFF
--- a/src/test/java/hudson/views/AbstractJenkinsTest.java
+++ b/src/test/java/hudson/views/AbstractJenkinsTest.java
@@ -8,18 +8,17 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
+import hudson.views.test.MockServletInputStream;
+import hudson.views.test.MockStaplerRequest;
+import hudson.views.test.MockStaplerResponse;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public abstract class AbstractJenkinsTest {
 
@@ -74,37 +73,9 @@ public abstract class AbstractJenkinsTest {
 
 		final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 
-		StaplerRequest request = mock(StaplerRequest.class);
-		when(request.getContentType()).thenReturn("application/xml");
-		when(request.getParameter("name")).thenReturn(view.getViewName());
-		when(request.getInputStream()).thenReturn(new ServletInputStream() {
-
-			@Override
-			public int read() throws IOException {
-				return in.read();
-			}
-
-			@Override
-			public boolean isFinished() {
-				return false;
-			}
-
-			@Override
-			public boolean isReady() {
-				return true;
-			}
-
-			@Override
-			public void setReadListener(ReadListener readListener) {
-			}
-
-			@Override
-			public void close() throws IOException {
-				in.close();
-			}
-		});
-
-		nestedView.doCreateView(request, mock(StaplerResponse.class));
+		StaplerRequest request = new MockStaplerRequest("application/xml", Map.of("name", view.getViewName()), new MockServletInputStream(in));
+		StaplerResponse response = new MockStaplerResponse();
+		nestedView.doCreateView(request, response);
 		return (T)nestedView.getView(view.getViewName());
 	}
 

--- a/src/test/java/hudson/views/test/MockServletInputStream.java
+++ b/src/test/java/hudson/views/test/MockServletInputStream.java
@@ -1,0 +1,40 @@
+package hudson.views.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+
+public class MockServletInputStream extends ServletInputStream {
+
+    private final InputStream in;
+
+    public MockServletInputStream(InputStream in) {
+        this.in = in;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return in.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/src/test/java/hudson/views/test/MockStaplerRequest.java
+++ b/src/test/java/hudson/views/test/MockStaplerRequest.java
@@ -1,0 +1,588 @@
+package hudson.views.test;
+
+import java.io.BufferedReader;
+import java.lang.reflect.Type;
+import java.security.Principal;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+import net.sf.json.JSONObject;
+import org.apache.commons.fileupload.FileItem;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.BindInterceptor;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebApp;
+import org.kohsuke.stapler.bind.BoundObjectTable;
+import org.kohsuke.stapler.lang.Klass;
+
+public class MockStaplerRequest implements StaplerRequest {
+    private final String contentType;
+    private final Map<String, String> parameters;
+    private final ServletInputStream is;
+
+    public MockStaplerRequest(String contentType, Map<String, String> parameters, ServletInputStream is) {
+        this.contentType = Objects.requireNonNull(contentType);
+        this.parameters = Objects.requireNonNull(parameters);
+        this.is = Objects.requireNonNull(is);
+    }
+
+    @Override
+    public Stapler getStapler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WebApp getWebApp() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRestOfPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getOriginalRestOfPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getContentLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return is;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return Collections.enumeration(parameters.keySet());
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return new String[] {parameters.get(name)};
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getScheme() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getServerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestURIWithQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StringBuffer getRequestURLWithQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getView(Object it, String viewName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getView(Class clazz, String viewName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getView(Klass<?> clazz, String viewName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRootPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getReferer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Ancestor> getAncestors() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Ancestor findAncestor(Class type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T findAncestorObject(Class<T> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Ancestor findAncestor(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasParameter(String name) {
+        return parameters.containsKey(name);
+    }
+
+    @Override
+    public String getOriginalRequestURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkIfModified(long timestampOfResource, StaplerResponse rsp) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkIfModified(Date timestampOfResource, StaplerResponse rsp) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkIfModified(Calendar timestampOfResource, StaplerResponse rsp) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkIfModified(long timestampOfResource, StaplerResponse rsp, long expiration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bindParameters(Object bean) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bindParameters(Object bean, String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<T> bindParametersToList(Class<T> type, String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T bindParameters(Class<T> type, String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T bindParameters(Class<T> type, String prefix, int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T bindJSON(Class<T> type, JSONObject src) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T bindJSON(Type genericType, Class<T> erasure, Object json) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bindJSON(Object bean, JSONObject src) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<T> bindJSONToList(Class<T> type, Object src) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BindInterceptor getBindInterceptor() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BindInterceptor setBindListener(BindInterceptor bindListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BindInterceptor setBindInterceptpr(BindInterceptor bindListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BindInterceptor setBindInterceptor(BindInterceptor bindListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JSONObject getSubmittedForm() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileItem getFileItem(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isJavaScriptProxyCall() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BoundObjectTable getBoundObjectTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String createJavaScriptProxy(Object toBeExported) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getAuthType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathTranslated() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContextPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServletPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void login(String username, String password) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logout() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Part getPart(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/hudson/views/test/MockStaplerResponse.java
+++ b/src/test/java/hudson/views/test/MockStaplerResponse.java
@@ -1,0 +1,310 @@
+package hudson.views.test;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Locale;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import net.sf.json.JsonConfig;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.Flavor;
+
+public class MockStaplerResponse implements StaplerResponse {
+
+    private int sc;
+
+    @Override
+    public void forward(Object it, String url, StaplerRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void forwardToPreviousPage(StaplerRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendRedirect2(@NonNull String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendRedirect(int statusCore, @NonNull String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(StaplerRequest request, URL res) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(StaplerRequest request, URL res, long expiration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveLocalizedFile(StaplerRequest request, URL res) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveLocalizedFile(StaplerRequest request, URL res, long expiration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(
+            StaplerRequest req,
+            InputStream data,
+            long lastModified,
+            long expiration,
+            long contentLength,
+            String fileName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(
+            StaplerRequest req,
+            InputStream data,
+            long lastModified,
+            long expiration,
+            int contentLength,
+            String fileName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(
+            StaplerRequest req, InputStream data, long lastModified, long contentLength, String fileName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveFile(StaplerRequest req, InputStream data, long lastModified, int contentLength, String fileName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream getCompressedOutputStream(HttpServletRequest req) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Writer getCompressedWriter(HttpServletRequest req) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int reverseProxyTo(URL url, StaplerRequest req) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setJsonConfig(JsonConfig config) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonConfig getJsonConfig() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendError(int sc, String msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendError(int sc) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendRedirect(String location) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(int sc) {
+        this.sc = sc;
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getStatus() {
+        return sc;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentType(String type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBufferSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushBuffer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetBuffer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCommitted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
The use of Mockito for mocking servlet classes is incomaptible with the compatibility layer being developed for EE 9 support in https://github.com/jenkinsci/javax-servlet-api/pull/5. To prepare this plugin for the migration, create a mock implementation of the interface without Mockito (i.e., a fake rather than a mock), which is compatible with the abovementioned compatibility layer.

### Testing done

Tested before and after the EE 9 migration.