### PR TITLE
[JENKINS-73969] [JENKINS-73970] Remove inline JavaScript to become CSP compliant

### DIFF
--- a/src/main/resources/hudson/views/OtherViewsFilter/config.jelly
+++ b/src/main/resources/hudson/views/OtherViewsFilter/config.jelly
@@ -6,9 +6,9 @@
 		<j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
 			<j:arg value="${it}" type="hudson.model.View"/>
 		</j:invokeStatic>
-    <f:invisibleEntry>
-      <f:textbox name="viewName" value="${thisViewName}"/>
-    </f:invisibleEntry>
+		<f:invisibleEntry>
+			<f:textbox name="viewName" value="${thisViewName}"/>
+		</f:invisibleEntry>
 		<f:select checkUrl="${rootURL}/descriptorByName/hudson.views.OtherViewsFilter/checkOtherViewName" checkDependsOn="viewName otherViewName"/>
 	</f:entry>
 	<st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>

--- a/src/main/resources/hudson/views/OtherViewsFilter/config.jelly
+++ b/src/main/resources/hudson/views/OtherViewsFilter/config.jelly
@@ -6,7 +6,10 @@
 		<j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
 			<j:arg value="${it}" type="hudson.model.View"/>
 		</j:invokeStatic>
-		<f:select checkUrl="'${rootURL}/descriptorByName/hudson.views.OtherViewsFilter/checkOtherViewName?otherViewName=' + encodeURIComponent((this.options.length == 0) ? '' : this.options[this.selectedIndex].value) + '&amp;viewName=' + encodeURIComponent('${h.jsStringEscape(thisViewName)}')"/>
+    <f:invisibleEntry>
+      <f:textbox name="viewName" value="${thisViewName}"/>
+    </f:invisibleEntry>
+		<f:select checkUrl="${rootURL}/descriptorByName/hudson.views.OtherViewsFilter/checkOtherViewName" checkDependsOn="viewName otherViewName"/>
 	</f:entry>
 	<st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>
 </j:jelly>

--- a/src/main/resources/hudson/views/RegExJobFilter/config.jelly
+++ b/src/main/resources/hudson/views/RegExJobFilter/config.jelly
@@ -3,7 +3,7 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <f:entry title="${%Regular Expression}:">
-      <f:textbox name="regex" field="regex" checkUrl="${rootURL}/descriptorByName/hudson.views.RegExJobFilter/checkRegex" checkDependsOn=""/>
+    <f:textbox name="regex" field="regex" checkUrl="${rootURL}/descriptorByName/hudson.views.RegExJobFilter/checkRegex" checkDependsOn=""/>
   </f:entry>
   <f:entry title="${%Match Value}:">
     <div class="valueType">

--- a/src/main/resources/hudson/views/RegExJobFilter/config.jelly
+++ b/src/main/resources/hudson/views/RegExJobFilter/config.jelly
@@ -3,12 +3,12 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <f:entry title="${%Regular Expression}:">
-    <f:textbox name="regex" field="regex" checkUrl="${rootURL}/descriptorByName/hudson.views.RegExJobFilter/checkRegex" checkDependsOn=""/>
+    <f:textbox name="regex" field="regex"/>
   </f:entry>
   <f:entry title="${%Match Value}:">
     <div class="valueType">
       <div class="jenkins-select jenkins-!-margin-bottom-2">
-        <select name="valueTypeString" class="jenkins-select__input" onchange="this.parentElement.querySelector('.nameOptions').style.display = ((this.options[this.selectedIndex].value.match(/NAME/)) ? 'block' : 'none')">
+        <select name="valueTypeString" class="jenkins-select__input vjf-regex-select">
           <f:option value="NAME" selected="${instance.valueTypeString == 'NAME'}">${%Job name}</f:option>
           <f:option value="FOLDER_NAME" selected="${instance.valueTypeString == 'FOLDER_NAME'}">${%Job folder name}</f:option>
           <f:option value="DESCRIPTION" selected="${instance.valueTypeString == 'DESCRIPTION'}">${%Job description}</f:option>
@@ -19,7 +19,7 @@
           <f:option value="NODE" selected="${instance.valueTypeString == 'NODE'}">${%Node label expression}</f:option>
         </select>
       </div>
-      <div class="nameOptions" style="display: ${(empty instance.valueTypeString || instance.valueTypeString.contains('NAME')) ? 'block' : 'none'}">
+      <div class="nameOptions ${(empty instance.valueTypeString || instance.valueTypeString.contains('NAME')) ? '' : 'jenkins-hidden'}">
         <div>
           <f:checkbox title="${%Name}" field="matchName" default="true"/>
         </div>
@@ -36,4 +36,5 @@
     </div>
   </f:entry>
   <st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>
+  <st:adjunct includes="hudson.views.RegExJobFilter.nameOptions"/>
 </j:jelly>

--- a/src/main/resources/hudson/views/RegExJobFilter/config.jelly
+++ b/src/main/resources/hudson/views/RegExJobFilter/config.jelly
@@ -3,7 +3,7 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <f:entry title="${%Regular Expression}:">
-      <f:textbox name="regex" field="regex" checkUrl="'${rootURL}/descriptorByName/hudson.views.RegExJobFilter/checkRegex?value='+encodeURIComponent(this.value)"/>
+      <f:textbox name="regex" field="regex" checkUrl="${rootURL}/descriptorByName/hudson.views.RegExJobFilter/checkRegex" checkDependsOn=""/>
   </f:entry>
   <f:entry title="${%Match Value}:">
     <div class="valueType">

--- a/src/main/resources/hudson/views/RegExJobFilter/nameOptions.js
+++ b/src/main/resources/hudson/views/RegExJobFilter/nameOptions.js
@@ -1,0 +1,6 @@
+Behaviour.specify(".vjf-regex-select", "vjf-regex-select", 0, function (e) {
+  e.addEventListener("change", function () {
+    const nameOptions = e.closest(".valueType").querySelector(".nameOptions");
+    nameOptions.classList.toggle("jenkins-hidden", !e.options[e.selectedIndex].value.match(/NAME/))
+  });
+});

--- a/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
+++ b/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
@@ -5,7 +5,7 @@
 	<j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
 		<j:arg value="${it}" type="hudson.model.View"/>
 	</j:invokeStatic>
-  <f:invisibleEntry>
+	<f:invisibleEntry>
 		<f:textbox name="viewName" value="${thisViewName}"/>
 	</f:invisibleEntry>
 	<f:entry>

--- a/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
+++ b/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
@@ -2,12 +2,12 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
-    <j:arg value="${it}" type="hudson.model.View"/>
-  </j:invokeStatic>
+	<j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
+		<j:arg value="${it}" type="hudson.model.View"/>
+	</j:invokeStatic>
   <f:invisibleEntry>
-    <f:textbox name="viewName" value="${thisViewName}"/>
-  </f:invisibleEntry>
+		<f:textbox name="viewName" value="${thisViewName}"/>
+	</f:invisibleEntry>
 	<f:entry>
     <div style="display:none">
 		<f:textbox name="dummy" checkUrl="${rootURL}/descriptorByName/hudson.views.UnclassifiedJobsFilter/check" checkDependsOn="viewName"/>

--- a/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
+++ b/src/main/resources/hudson/views/UnclassifiedJobsFilter/config.jelly
@@ -2,12 +2,15 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
-		<j:arg value="${it}" type="hudson.model.View"/>
-	</j:invokeStatic>
+  <j:invokeStatic className="hudson.views.ViewGraph" method="toName" var="thisViewName">
+    <j:arg value="${it}" type="hudson.model.View"/>
+  </j:invokeStatic>
+  <f:invisibleEntry>
+    <f:textbox name="viewName" value="${thisViewName}"/>
+  </f:invisibleEntry>
 	<f:entry>
     <div style="display:none">
-		<f:textbox name="dummy" checkUrl="'${rootURL}/descriptorByName/hudson.views.UnclassifiedJobsFilter/check?viewName=' + encodeURIComponent('${h.jsStringEscape(thisViewName)}')"/>
+		<f:textbox name="dummy" checkUrl="${rootURL}/descriptorByName/hudson.views.UnclassifiedJobsFilter/check" checkDependsOn="viewName"/>
     </div>
     </f:entry>
 	<st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>

--- a/src/main/resources/hudson/views/UserRelevanceFilter/config.jelly
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/config.jelly
@@ -29,31 +29,11 @@
     </div>
     <div>
       <f:checkbox title="${%Match jobs with builds 'started by' user}" name="matchBuilder" field="matchBuilder" default="true"
-                  onclick="showOrHideBuildOptions(this)"/>
+                  class="showOrHideBuildOptions"/>
     </div>
     <div>
       <f:checkbox title="${%Match jobs with builds where user is source code committer}" name="matchScmChanges" field="matchScmChanges"
-                  default="true" onclick="showOrHideBuildOptions(this)"/>
-    </div>
-    <div class="showOrHideBuildOptions">
-    <script>
-      function showOrHideBuildOptions(elem) {
-        var jobFilter = elem.closest('[name="jobFilters"]');
-        var matchBuilder = jobFilter.querySelector('[name="matchBuilder"]');
-        var matchScmChanges = jobFilter.querySelector('[name="matchScmChanges"]');
-
-        var tr2 = jobFilter.querySelector('[name="buildCountTypeString"]').parentElement.parentElement.parentElement;
-        var tr3 = jobFilter.querySelector('[name="amountTypeString"]').parentElement.parentElement.parentElement;
-
-        if (matchBuilder.checked || matchScmChanges.checked) {
-          tr2.classList.remove('jenkins-hidden');
-          tr3.classList.remove('jenkins-hidden');
-        } else {
-          tr2.classList.add('jenkins-hidden');
-          tr3.classList.add('jenkins-hidden');
-        }
-      }
-    </script>
+                  class="showOrHideBuildOptions"/>
     </div>
   </f:entry>
   <f:entry title="${%Build trend type}:">
@@ -66,7 +46,5 @@
     </div>
   </f:entry>
   <st:include page="config.jelly" class="hudson.views.AbstractBuildTrendFilter" optional="false"/>
-  <script>
-    Array.prototype.forEach.call(document.querySelectorAll('.showOrHideBuildOptions'), showOrHideBuildOptions);
-  </script>
+  <st:adjunct includes="hudson.views.UserRelevanceFilter.showOptions"/>
 </j:jelly>

--- a/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
@@ -18,6 +18,6 @@ function showOrHideBuildOptions(elem) {
 Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function (element) {
   element.addEventListener("click", function () {
     showOrHideBuildOptions(element);
-  };
+  });
   showOrHideBuildOptions(element);
 });

--- a/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
@@ -1,0 +1,24 @@
+function showOrHideBuildOptions(elem) {
+  var jobFilter = elem.closest('[name="jobFilters"]');
+  var matchBuilder = jobFilter.querySelector('[name="matchBuilder"]');
+  var matchScmChanges = jobFilter.querySelector('[name="matchScmChanges"]');
+
+  var tr2 = jobFilter.querySelector('[name="buildCountTypeString"]').parentElement.parentElement.parentElement;
+  var tr3 = jobFilter.querySelector('[name="amountTypeString"]').parentElement.parentElement.parentElement;
+
+  if (matchBuilder.checked || matchScmChanges.checked) {
+    tr2.classList.remove('jenkins-hidden');
+    tr3.classList.remove('jenkins-hidden');
+  } else {
+    tr2.classList.add('jenkins-hidden');
+    tr3.classList.add('jenkins-hidden');
+  }
+}
+
+Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function(element) {
+  element.onclick = function() {
+    showOrHideBuildOptions(element);
+  }
+  showOrHideBuildOptions(element);
+});
+

--- a/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
@@ -16,7 +16,7 @@ function showOrHideBuildOptions(elem) {
 }
 
 Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function (element) {
-  element.onclick = function () {
+  element.addEventListener("click", function () {
     showOrHideBuildOptions(element);
   };
   showOrHideBuildOptions(element);

--- a/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
@@ -7,18 +7,17 @@ function showOrHideBuildOptions(elem) {
   var tr3 = jobFilter.querySelector('[name="amountTypeString"]').parentElement.parentElement.parentElement;
 
   if (matchBuilder.checked || matchScmChanges.checked) {
-    tr2.classList.remove('jenkins-hidden');
-    tr3.classList.remove('jenkins-hidden');
+    tr2.classList.remove("jenkins-hidden");
+    tr3.classList.remove("jenkins-hidden");
   } else {
-    tr2.classList.add('jenkins-hidden');
-    tr3.classList.add('jenkins-hidden');
+    tr2.classList.add("jenkins-hidden");
+    tr3.classList.add("jenkins-hidden");
   }
 }
 
 Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function (element) {
   element.onclick = function () {
     showOrHideBuildOptions(element);
-  }
+  };
   showOrHideBuildOptions(element);
 });
-

--- a/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
+++ b/src/main/resources/hudson/views/UserRelevanceFilter/showOptions.js
@@ -15,8 +15,8 @@ function showOrHideBuildOptions(elem) {
   }
 }
 
-Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function(element) {
-  element.onclick = function() {
+Behaviour.specify(".showOrHideBuildOptions", "showOrHideBuildOptions", 0, function (element) {
+  element.onclick = function () {
     showOrHideBuildOptions(element);
   }
   showOrHideBuildOptions(element);


### PR DESCRIPTION
use checkDependsOn for checkUrl
move the script for UserRelevanceFilter to a separate js file and load as adjunct
fix that nameOptions were not hidden when when selecting a non name matcher in regex filter

<!-- Please describe your pull request here. -->

### Testing done
Manual Testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
