### PR TITLE
Add a filter for job status NOT_BUILT

### DIFF
--- a/src/main/java/hudson/views/JobStatusFilter.java
+++ b/src/main/java/hudson/views/JobStatusFilter.java
@@ -9,6 +9,7 @@ import hudson.model.TopLevelItem;
 import jenkins.model.ParameterizedJobMixIn;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class JobStatusFilter extends AbstractIncludeExcludeJobFilter {
 	
@@ -17,6 +18,7 @@ public class JobStatusFilter extends AbstractIncludeExcludeJobFilter {
 	private boolean aborted;
 	private boolean disabled;
 	private boolean stable;
+	private boolean notBuilt;
 	
 	@DataBoundConstructor
 	public JobStatusFilter(boolean unstable, boolean failed, boolean aborted, 
@@ -29,6 +31,12 @@ public class JobStatusFilter extends AbstractIncludeExcludeJobFilter {
 		this.disabled = disabled;
 		this.stable = stable;
 	}
+
+    @DataBoundSetter
+	public void setNotBuilt(boolean notBuilt) {
+		this.notBuilt = notBuilt;
+	}
+
 	@SuppressWarnings("rawtypes")
 	protected boolean matches(TopLevelItem item) {
 		if (item instanceof ParameterizedJobMixIn.ParameterizedJob) {
@@ -52,6 +60,9 @@ public class JobStatusFilter extends AbstractIncludeExcludeJobFilter {
 					return true;
 				}
 				if (unstable && result == Result.UNSTABLE) {
+					return true;
+				}
+				if (notBuilt && result == Result.NOT_BUILT) {
 					return true;
 				}
 			}
@@ -85,5 +96,8 @@ public class JobStatusFilter extends AbstractIncludeExcludeJobFilter {
 	}
 	public boolean isStable() {
 		return stable;
+	}
+	public boolean isNotBuilt() {
+		return notBuilt;
 	}
 }

--- a/src/main/resources/hudson/views/JobStatusFilter/config.jelly
+++ b/src/main/resources/hudson/views/JobStatusFilter/config.jelly
@@ -18,6 +18,9 @@
     <div>
       <f:checkbox title="${%Disabled}" field="disabled"/>
     </div>
+    <div>
+      <f:checkbox title="${%Not built}" field="notBuilt"/>
+    </div>
   </f:entry>
   <st:include page="config.jelly" class="hudson.views.AbstractIncludeExcludeJobFilter" optional="false"/>
 </j:jelly>

--- a/src/main/resources/hudson/views/JobStatusFilter/config_de.properties
+++ b/src/main/resources/hudson/views/JobStatusFilter/config_de.properties
@@ -4,3 +4,4 @@ Failed=Fehlgeschlagen
 Unstable=Instabil
 Aborted=Abgebrochen
 Disabled=Deaktiviert
+Not\ built=Nicht gebaut

--- a/src/test/java/hudson/views/JobStatusFilterTest.java
+++ b/src/test/java/hudson/views/JobStatusFilterTest.java
@@ -25,42 +25,54 @@ public class JobStatusFilterTest extends AbstractJenkinsTest {
 	@Test
 	@WithoutJenkins
 	public void testMatch() {
-		assertFalse(jobStatus(true, true, true, true, true).matches(mock(TopLevelItem.class)));
+		assertFalse(jobStatus(true, true, true, true, true, true).matches(mock(TopLevelItem.class)));
 
 		for (JobType<? extends Job> type: availableJobTypes(FREE_STYLE_PROJECT, MATRIX_PROJECT, MAVEN_MODULE_SET, WORKFLOW_JOB)) {
-			assertFalse(jobStatus(true, true, true, true, true).matches(jobOfType(type).asItem()));
+			assertFalse(jobStatus(true, true, true, true, true, true).matches(jobOfType(type).asItem()));
 
-			assertTrue(jobStatus(true, false, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
-			assertFalse(jobStatus(true, false, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
-			assertFalse(jobStatus(true, false, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
-			assertFalse(jobStatus(true, false, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
-			assertFalse(jobStatus(true, false, false, false, false).matches(jobOfType(type).disabled(true).asItem()));
+			assertTrue(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertFalse(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertFalse(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertFalse(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertFalse(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
+			assertFalse(jobStatus(true, false, false, false, false, false).matches(jobOfType(type).disabled(true).asItem()));
 
-			assertFalse(jobStatus(false, true, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
-			assertTrue(jobStatus(false, true, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
-			assertFalse(jobStatus(false, true, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
-			assertFalse(jobStatus(false, true, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
-			assertFalse(jobStatus(false, true, false, false, false).matches(jobOfType(type).disabled(true).asItem()));
+			assertFalse(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertTrue(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertFalse(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertFalse(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertFalse(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
+			assertFalse(jobStatus(false, true, false, false, false, false).matches(jobOfType(type).disabled(true).asItem()));
 
-			assertFalse(jobStatus(false, false, true, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
-			assertFalse(jobStatus(false, false, true, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
-			assertTrue(jobStatus(false, false, true, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
-			assertFalse(jobStatus(false, false, true, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
-			assertFalse(jobStatus(false, false, true, false, false).matches(jobOfType(type).disabled(true).asItem()));
+			assertFalse(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertFalse(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertTrue(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertFalse(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertFalse(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
+			assertFalse(jobStatus(false, false, true, false, false, false).matches(jobOfType(type).disabled(true).asItem()));
 
-			assertFalse(jobStatus(false, false, false, false, true).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
-			assertFalse(jobStatus(false, false, false, false, true).matches(jobOfType(type).result(Result.FAILURE).asItem()));
-			assertFalse(jobStatus(false, false, false, false, true).matches(jobOfType(type).result(Result.ABORTED).asItem()));
-			assertTrue(jobStatus(false, false, false, false, true).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
-			assertFalse(jobStatus(false, false, false, false, true).matches(jobOfType(type).disabled(true).asItem()));
+			assertFalse(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertFalse(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertFalse(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertTrue(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertFalse(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
+			assertFalse(jobStatus(false, false, false, false, true, false).matches(jobOfType(type).disabled(true).asItem()));
 
-			assertTrue("works on " + type.getJobClass().getSimpleName(), jobStatus(false, false, false, true, false).matches(jobOfType(type).disabled(true).asItem()));
-			assertFalse(jobStatus(false, false, false, true, false).matches(jobOfType(type).disabled(false).asItem()));
+			assertFalse(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertFalse(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertFalse(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertFalse(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertTrue(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
+			assertFalse(jobStatus(false, false, false, false, false, true).matches(jobOfType(type).disabled(true).asItem()));
 
-			assertTrue(jobStatus(true, true, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
-			assertTrue(jobStatus(true, true, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
-			assertFalse(jobStatus(true, true, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
-			assertFalse(jobStatus(true, true, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertTrue("works on " + type.getJobClass().getSimpleName(), jobStatus(false, false, false, true, false, false).matches(jobOfType(type).disabled(true).asItem()));
+			assertFalse(jobStatus(false, false, false, true, false, false).matches(jobOfType(type).disabled(false).asItem()));
+
+			assertTrue(jobStatus(true, true, false, false, false, false).matches(jobOfType(type).result(Result.UNSTABLE).asItem()));
+			assertTrue(jobStatus(true, true, false, false, false, false).matches(jobOfType(type).result(Result.FAILURE).asItem()));
+			assertFalse(jobStatus(true, true, false, false, false, false).matches(jobOfType(type).result(Result.ABORTED).asItem()));
+			assertFalse(jobStatus(true, true, false, false, false, false).matches(jobOfType(type).result(Result.SUCCESS).asItem()));
+			assertFalse(jobStatus(true, true, false, false, false, false).matches(jobOfType(type).result(Result.NOT_BUILT).asItem()));
 		}
 	}
 
@@ -68,25 +80,26 @@ public class JobStatusFilterTest extends AbstractJenkinsTest {
 	public void testConfigRoundtrip() throws Exception {
 		testConfigRoundtrip(
 			"view-1",
-			new JobStatusFilter(false, true, false, true, false,  excludeMatched.name())
+			jobStatus(false, true, false, true, false,  false, excludeMatched.name())
 		);
 
 		testConfigRoundtrip(
 			"view-2",
-			new JobStatusFilter(true, false, true, false, true,  includeMatched.name()),
-			new JobStatusFilter(true, true, false, false, false,  excludeMatched.name())
+			jobStatus(true, false, true, false, true, true, includeMatched.name()),
+			jobStatus(true, true, false, false, false, false, excludeMatched.name())
 		);
 	}
 
 	private void testConfigRoundtrip(String viewName, JobStatusFilter... filters) throws Exception {
 		List<JobStatusFilter> expectedFilters = new ArrayList<JobStatusFilter>();
 		for (JobStatusFilter filter: filters) {
-			expectedFilters.add(new JobStatusFilter(
+			expectedFilters.add(jobStatus(
 				filter.isUnstable(),
 				filter.isFailed(),
 				filter.isAborted(),
 				filter.isDisabled(),
 				filter.isStable(),
+				filter.isNotBuilt(),
 				filter.getIncludeExcludeTypeString()));
 		}
 
@@ -114,6 +127,7 @@ public class JobStatusFilterTest extends AbstractJenkinsTest {
 			assertThat(((JobStatusFilter)actualFilter).isFailed(), is(expectedFilter.isFailed()));
 			assertThat(((JobStatusFilter)actualFilter).isStable(), is(expectedFilter.isStable()));
 			assertThat(((JobStatusFilter)actualFilter).isUnstable(), is(expectedFilter.isUnstable()));
+			assertThat(((JobStatusFilter)actualFilter).isNotBuilt(), is(expectedFilter.isNotBuilt()));
 			assertThat(((JobStatusFilter)actualFilter).getIncludeExcludeTypeString(), is(expectedFilter.getIncludeExcludeTypeString()));
 		}
 	}

--- a/src/test/java/hudson/views/test/ViewJobFilters.java
+++ b/src/test/java/hudson/views/test/ViewJobFilters.java
@@ -100,14 +100,28 @@ public class ViewJobFilters {
             boolean failed,
             boolean aborted,
             boolean disabled,
-            boolean stable) {
-        return new JobStatusFilter(
+            boolean stable,
+            boolean notBuilt,
+            String includeExcludeTypeString) {
+        JobStatusFilter jobStatusFilter = new JobStatusFilter(
                 unstable,
                 failed,
                 aborted,
                 disabled,
                 stable,
-                includeMatched.name());
+                includeExcludeTypeString);
+        jobStatusFilter.setNotBuilt(notBuilt);
+        return jobStatusFilter;
+    }
+
+    public static JobStatusFilter jobStatus(
+            boolean unstable,
+            boolean failed,
+            boolean aborted,
+            boolean disabled,
+            boolean stable,
+            boolean notBuilt) {
+        return jobStatus(unstable, failed, aborted, disabled, stable, notBuilt, includeMatched.name());
     }
 
     public static JobTypeFilter jobType(TopLevelItemDescriptor descriptor) {


### PR DESCRIPTION
the Job StatusFilter didn't allow to filter for jobs that have status NOT_BUILT. While not seen much usually it is a valid Result of a job so it should be possible to filter for this status.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
